### PR TITLE
Original DE ROM 319 for 5mx Pro

### DIFF
--- a/5mxPro/DE_orig/readme.txt
+++ b/5mxPro/DE_orig/readme.txt
@@ -1,0 +1,3 @@
+ROM for Psion 5mx Pro.
+Version 319 DE (Qwertz DE Keyboard)
+Original image of the latest ROM from the Psion CF card

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Some of this ROM files are upgraded (patched) to solve some bugs or add function
 Contents:
 
 - ROMs for Psion 5mx Pro, patched with 2 Additional Apps from Ericsson MC218 (MyPhone + PostCard) ([UK](5mxPro/UK/), [DE](5mxPro/DE/))
+- Original ROM for Psion 5mx Pro ([DE](5mxPro/DE_orig/))
 - ROMs for Psion netBook, patched with additional Apps and components([UK](netBook/UK/), [DE](netBook/DE), [FR](netBook/FR/), [SP](netBook/SP/))
-- Dumped ROM of Ericcson MC218 ([UK](MC218/UK/), [DE](MC218/DE/))
+- Dumped ROMs of Ericcson MC218 ([UK](MC218/UK/), [DE](MC218/DE/))
 - ROM Update for Series 7 ([UK](Series7/UK/), [US](Series7/US/))
 - Revo Firmware Dump ([DE](Revo/DE/))
 - Dumped ROM for Psion 5mx ([UK](5mx/UK/))


### PR DESCRIPTION
Original last DE ROM 319 for 5mx Pro from my Psion CF card.

I think it's worth posting for those who don't need additional applications from the MC218 (in addition, apps have problems described in #5).

As far as I understand, 5mx Pro only existed in Germany, so the original ROM image only exists in the German version.

Recently I also received a couple of ROM images (**5mx 250 UK** and **5mx Pro 273 DE**).
But they are older than the ones already here, so I doubt whether they are needed. If so, I can add them to the PR.