### PR TITLE
add romdump for Psion 5MX 1.05(260)

### DIFF
--- a/5mx/UK_260/readme.txt
+++ b/5mx/UK_260/readme.txt
@@ -1,0 +1,8 @@
+Version 1.05(260) - English (UK) - ASCII
+
+Taken from a retail Psion 5MX reporting 16MB RAM & ROM.
+
+PsiROMx default options used.
+Start Addr: 50000000
+Size (KB):  16384	
+End Addr:   51000000


### PR DESCRIPTION
Add new romdump for the Psion 5mx. 
This is a slightly newer version than the one currently in the repo, though I have no idea what's actually different.

Taken from a production 5mx.